### PR TITLE
Pass through robot position/orientation from XML

### DIFF
--- a/src/config/robot.yaml
+++ b/src/config/robot.yaml
@@ -2,10 +2,9 @@
 #   - robot1
 #   - robot2
 
-# Override the pose(s) and orientation(s) specified by the robot description(s).
-# pose_init:
-#   robot1: [5, 0, 0, 0, 0, 0] # for robot1
-#   robot2: [0, 1, 2, 0, 0, 0.79] # for robot2
+# pose_init: [0, 0, 0, 0, 0, 0] # Overrides xml specification
+#   - robot1: [0, 0, 0, 0, 0, 0] for robot1
+#   - robot2: [0, 1, 2, 0, 0, 3.14] for robot2
 
 # joint_inits: # Initialize the joint positions
 #   joint1: 0

--- a/src/config/robot.yaml
+++ b/src/config/robot.yaml
@@ -2,9 +2,13 @@
 #   - robot1
 #   - robot2
 
-# pose_init: [0, 0, 0, 0, 0, 0] # Overrides xml specification
-#   - robot1: [0, 0, 0, 0, 0, 0] for robot1
-#   - robot2: [0, 1, 2, 0, 0, 3.14] for robot2
+# Uncomment exactly one of the following blocks to set an initial pose which overrides 
+# the xml specification. The first block applies to all robots, the second block 
+# applies by name.
+# pose_init: [0, 0, 0, 0, 0, 0]
+# pose_init:
+#   robot1: [0, 0, 0, 0, 0, 0]  # for robot1
+#   robot2: [0, 1, 2, 0, 0, 3.14] # for robot2
 
 # joint_inits: # Initialize the joint positions
 #   joint1: 0

--- a/src/config/robot.yaml
+++ b/src/config/robot.yaml
@@ -2,9 +2,10 @@
 #   - robot1
 #   - robot2
 
-# pose_init: [0, 0, 0, 0, 0, 0] # Overrides xml specification
-#   - robot1: [0, 0, 0, 0, 0, 0] for robot1
-#   - robot2: [0, 1, 2, 0, 0, 3.14] for robot2
+# Override the pose(s) and orientation(s) specified by the robot description(s).
+# pose_init:
+#   robot1: [5, 0, 0, 0, 0, 0] # for robot1
+#   robot2: [0, 1, 2, 0, 0, 0.79] # for robot2
 
 # joint_inits: # Initialize the joint positions
 #   joint1: 0

--- a/src/config/robot.yaml
+++ b/src/config/robot.yaml
@@ -2,7 +2,7 @@
 #   - robot1
 #   - robot2
 
-# pose_init: [0, 0, 0, 0, 0, 0] for all robots
+# pose_init: [0, 0, 0, 0, 0, 0] # Overrides xml specification
 #   - robot1: [0, 0, 0, 0, 0, 0] for robot1
 #   - robot2: [0, 1, 2, 0, 0, 3.14] for robot2
 

--- a/src/mujoco_sim/mj_ros.cpp
+++ b/src/mujoco_sim/mj_ros.cpp
@@ -311,10 +311,6 @@ void MjRos::set_params()
             {
                 MjSim::pose_inits[robot] = pose_init;
             }
-            else
-            {
-                MjSim::pose_inits[robot] = std::vector<float>(6, 0.0);
-            }
         }
     }
 

--- a/src/mujoco_sim/mj_ros.cpp
+++ b/src/mujoco_sim/mj_ros.cpp
@@ -296,11 +296,21 @@ void MjRos::set_params()
     ROS_INFO("%s", log.c_str());
 
     std::vector<float> pose_init;
-    for (const std::string &robot : MjSim::robot_names)
+    if (ros::param::get("~pose_init", pose_init) && pose_init.size() == 6)
     {
-        if (ros::param::get("~pose_init/" + robot, pose_init) && pose_init.size() == 6)
+        for (const std::string &robot : MjSim::robot_names)
         {
             MjSim::pose_inits[robot] = pose_init;
+        }
+    }
+    else
+    {
+        for (const std::string &robot : MjSim::robot_names)
+        {
+            if (ros::param::get("~pose_init/" + robot, pose_init) && pose_init.size() == 6)
+            {
+                MjSim::pose_inits[robot] = pose_init;
+            }
         }
     }
 

--- a/src/mujoco_sim/mj_ros.cpp
+++ b/src/mujoco_sim/mj_ros.cpp
@@ -296,21 +296,11 @@ void MjRos::set_params()
     ROS_INFO("%s", log.c_str());
 
     std::vector<float> pose_init;
-    if (ros::param::get("~pose_init", pose_init) && pose_init.size() == 6)
+    for (const std::string &robot : MjSim::robot_names)
     {
-        for (const std::string &robot : MjSim::robot_names)
+        if (ros::param::get("~pose_init/" + robot, pose_init) && pose_init.size() == 6)
         {
             MjSim::pose_inits[robot] = pose_init;
-        }
-    }
-    else
-    {
-        for (const std::string &robot : MjSim::robot_names)
-        {
-            if (ros::param::get("~pose_init/" + robot, pose_init) && pose_init.size() == 6)
-            {
-                MjSim::pose_inits[robot] = pose_init;
-            }
         }
     }
 

--- a/src/mujoco_sim/mj_sim.cpp
+++ b/src/mujoco_sim/mj_sim.cpp
@@ -314,7 +314,10 @@ static void init_tmp()
 			 robot_body = robot_body->NextSiblingElement("body"))
 		{
 			const char *robot = robot_body->Attribute("name");
-			if (robot != nullptr && MjSim::robot_names.find(robot) != MjSim::robot_names.end() && MjSim::pose_inits.find(robot) != MjSim::pose_inits.end() && MjSim::pose_inits[robot].size() == 6)
+			if (robot != nullptr &&
+				MjSim::robot_names.find(robot) != MjSim::robot_names.end() &&
+				MjSim::pose_inits.find(robot) != MjSim::pose_inits.end() &&
+				MjSim::pose_inits[robot].size() == 6)
 			{
 				robot_body->SetAttribute("pos", (std::to_string(MjSim::pose_inits[robot][0]) + " " +
 												 std::to_string(MjSim::pose_inits[robot][1]) + " " +


### PR DESCRIPTION
Currently the robot pose from the XML is always overwritten, even when the `pose_init` parameter is not set. This PR fixes that, and also clarifies the structure for setting `pose_init` by removing the option to set all robots to the same pose.